### PR TITLE
Add do syntax to AbstractFormattedIO built from other IO objects

### DIFF
--- a/src/IO.jl
+++ b/src/IO.jl
@@ -14,6 +14,15 @@ module IO
 "Abstract formatted input/output type."
 abstract type AbstractFormattedIO end
 
+function (::Type{T})(f, io::IO) where {T <: AbstractFormattedIO}
+    fmt = T(io)
+    try
+        f(fmt)
+    finally
+        close(fmt)
+    end
+end
+
 """
     stream(io::AbstractFormattedIO)
 

--- a/src/IO.jl
+++ b/src/IO.jl
@@ -14,7 +14,7 @@ module IO
 "Abstract formatted input/output type."
 abstract type AbstractFormattedIO end
 
-function (::Type{T})(f, io::IO) where {T <: AbstractFormattedIO}
+function (::Type{T})(f, io::Base.IO) where {T <: AbstractFormattedIO}
     fmt = T(io)
     try
         f(fmt)


### PR DESCRIPTION
This PR adds the ability to use `do` syntax for `AbstractFormattedIO` build from IO objects.

For example, suppose you want to get the first record of a gzipped FASTA file. Before, you had to do:
```
record = open(path) do file
    reader = GzipDecompressorStream(file)
    record = first(iterate(reader))
    close(reader)
    record
end
```
With this PR, you can do
```
record = FASTA.Reader(GzipDecompressorStream(open(path))) do reader
    first(iterate(reader))
end
```