### PR TITLE
Improve inferrability of writer kwargs

### DIFF
--- a/src/IO.jl
+++ b/src/IO.jl
@@ -91,7 +91,11 @@ See `subtypes(AbstractWriter)` for all available data writers.
 abstract type AbstractWriter <: AbstractFormattedIO end
 
 function Base.open(::Type{T}, filepath::AbstractString, args...; kwargs_...) where T <: AbstractWriter
-    kwargs = collect(kwargs_)
+    # Special case to improve inference by avoiding the kwarg stuff
+    if isempty(kwargs_)
+        return T(open(filepath, "w"), args...)
+    end
+    kwargs::Vector{<:Pair{Symbol}} = collect(kwargs_)
     i = findfirst(kwarg -> kwarg[1] == :append, kwargs)
     if i !== nothing
         append = kwargs[i][2]


### PR DESCRIPTION
Honestly, I'm not super fond of a few of the methods in `IO.jl`. It's nice and convenient, but it needs to be a little more general (e.g. #5), and I think the stunt with passing all kwargs, *except* `:append` from `open(::AbstractWriter, ::AbstractString, args...; kwargs...)` into the Writer constructor is a little shady.

But that's a tale for another time. The PR right here fixes an inferrability issue. If there were no kwargs, then the vector of kwargs would have the inferred eltype `Pair{Bottom, Bottom}`, which is meaningless. That doesn't lead to any bad behaviour (because its elements can never be extracted, since the vector will be empty), but it does lead to some weird code generation with weird types.

Anyway, merging this shouldn't make a difference in behaviour or anything, just what the compiler can statically infer.