### PR TITLE
Add the more abstract `groupname` and `hasgroupname`.

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -19,6 +19,8 @@ end
 # Base functions used in (and exported from) BioJulia packages.
 @declare (
     distance,
+    groupname,
+    hasgroupname,
     seqname,
     hasseqname,
     sequence,


### PR DESCRIPTION
Comparable record fields do not necessarily have the same name (https://github.com/BioJulia/XAM.jl/issues/42) and sometimes an end-user may want to group on something more abstract by overwriting a method, `groupname` is sufficiently different for this purpose, and is also sufficiently different from common field names to be abstract.

This method will be used by `GenomicFeatures`.