### PR TITLE
Add varargs and kwargs to T(open(f, ::IO)) methods

### DIFF
--- a/src/IO.jl
+++ b/src/IO.jl
@@ -14,8 +14,8 @@ module IO
 "Abstract formatted input/output type."
 abstract type AbstractFormattedIO end
 
-function (::Type{T})(f, io::Base.IO) where {T <: AbstractFormattedIO}
-    fmt = T(io)
+function (::Type{T})(f::Function, io::Base.IO, args...; kwargs...) where {T <: AbstractFormattedIO}
+    fmt = T(io, args...; kwargs...)
     try
         f(fmt)
     finally


### PR DESCRIPTION
This allows users to do things like:
```
FASTA.Reader(GzipDecompressorStream(open(path)), copy=true) do reader
    # do stuff with reader
end
```
thus making the user interface a little nicer.