### PR TITLE
Add rdr and wrt string macros and transcribe

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BioGenerics"
 uuid = "47718e42-2ac5-11e9-14af-e5595289c2ea"
 authors = ["Ben J. Ward <benjward@protonmail.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"

--- a/src/BioGenerics.jl
+++ b/src/BioGenerics.jl
@@ -17,4 +17,6 @@ include("IO.jl")
 #include("RecordHelper.jl")
 include("Testing.jl")
 
+using .IO: readertype, writertype, @rdr_str, @wtr_str
+
 end # module BioGenerics

--- a/src/IO.jl
+++ b/src/IO.jl
@@ -118,6 +118,115 @@ function Base.open(::Type{T}, filepath::AbstractString, args...; kwargs_...) whe
     return T(open(filepath, append ? "a" : "w"), args...; kwargs...)
 end
 
-# 
+# We have this un-extendable function here because we expect
+# to not be able to control compression-related code, whereas we might be able to get
+# PRs to biological readers
+# That's also why we return code here instead of objects - BioGenerics does not need
+# to know what GzipDecompressorStream is, so we just return a symbol that could be anything,
+# and let the module that used the macro resolve it.
+function de_compressor_code(ending::Union{String, SubString{String}}, read::Bool)
+    # TODO: It would be nice to have a good specialized BGZIP implementation...
+    if in(ending, ("gzip", "gz", "bgzip"))
+        read ? quote GzipDecompressorStream end : quote GzipCompressorStream end
+    elseif ending == "xz"
+        read ? quote XzDecompressorStream end : quote XzCompressorStream end
+    elseif ending == "zst"
+        read ? quote ZstdDecompressorStream end : quote ZstdCompressorStream end
+    else
+        nothing
+    end
+end
+
+"""
+    readertype(::Val{S}, arg)::T
+
+Determine the type of reader that opens extension named by `Symbol` `S`.
+For example, `readertype(::Val{:fa}, arg) = FASTA.Reader`.
+Should be extended by developers making new biological file format readers.
+
+The extra argument `arg` can be passed like so `rdr"path.ext"arg`, and defaults
+to the empty string. This can be used to pass an additional argument that is specific
+to the person implementing the reader.
+"""
+readertype(@nospecialize(v::Val{S}), arg) where S = error("Unknown biological file extension: \"$(string(S))\"")
+
+"""
+    writertype(::Val{S}, arg)::T
+
+Determine the type of reader that can write a file with an extension named by `Symbol` `S`.
+For example, `writertype(::Val{:fa}, arg) = FASTA.Writer`.
+Should be extended by developers making new biological file format writers.
+
+The extra argument `arg` can be passed like so `wtr"path.ext"arg`, and defaults
+to the empty string. This can be used to pass an additional argument that is specific
+to the person implementing the writer.
+"""
+writertype(@nospecialize(v::Val{S}), arg) where S = error("Unknown biological file extension: \"$(string(S))\"")
+
+# Like splitext, but removes the dot from the extension
+function pure_ext(path::Union{String, SubString{String}})
+    (path, ext) = splitext(path)
+    ext = (!isempty(ext) && first(ext) == '.') ? ext[2:end] : ext
+    String(path), String(ext)
+end
+
+function resolve_reader(path::Union{String, SubString{String}}, arg::String)
+    code = quote open($(path); lock=false) end
+    (path, ext) = pure_ext(path)
+    while (wrapper = de_compressor_code(ext, true)) !== nothing 
+        code = quote $(wrapper)($code) end
+        (path, ext) = pure_ext(path)
+    end
+    quote $(readertype(Val(Symbol(ext)), arg))($code) end
+end
+
+function resolve_writer(path::Union{String, SubString{String}}, arg::String)
+    code = quote open($(path), "w"; lock=false) end
+    (path, ext) = pure_ext(path)
+    while (wrapper = de_compressor_code(ext, false)) !== nothing 
+        code = quote $(wrapper)($code) end
+        (path, ext) = pure_ext(path)
+    end
+    quote $(writertype(Val(Symbol(ext)), arg))($code) end
+end
+
+macro rdr_str(path, arg)
+    esc(resolve_reader(path, arg))
+end
+
+macro rdr_str(path)
+    esc(resolve_reader(path, ""))
+end
+
+macro wtr_str(path, arg)
+    esc(resolve_writer(path, arg))
+end
+
+macro wtr_str(path)
+    esc(resolve_writer(path, ""))
+end
+
+"""
+    Base.open(f, ios::Vararg{AbstractFormattedIO})
+
+Execute `f(ios...)`, then `close` each io.
+`close` is run even if `f(ios...)` throws an exception.
+
+# Examples
+```julia
+julia> open(rdr"path/to/seqs.fna") do reader
+           # do something with reader
+       end
+```
+"""
+function Base.open(f::Function, first::AbstractFormattedIO, rest::Vararg{AbstractFormattedIO})
+    try
+        f(first, rest...)
+    finally
+        for i in (first, rest...)
+            close(i)
+        end
+    end
+end
 
 end  # module BioGenerics.IO


### PR DESCRIPTION
This is a whack at https://github.com/BioJulia/FASTX.jl/issues/76 . I've done it in this repo so it can affect all `AbstractReader`s and `AbstractWriter`s.

This PR implements two new high-level operations that are convenient shorthands for already existing operations. I would like to get any feedback, especially regarding
* Is it convenient enough? Could something be made nicer?
* Is it extendible and flexible enough? Currently, I have FASTX on my mind and may not consider the general case. I.e. what would someone do with a VCF writer, or some writer that requires a footer, etc

## Reader and writer macros
This allows a user to type e.g. `wtr"dir/hiv.fna.gz"`, which expands to `FASTA.Writer(GzipCompressorStream(open("dir/hiv.fna.gz", "w")))`, and a similar `rdr"path"` macro. Here is how it works: Let's use  `rdr"abc.fa.gzip.xz.gz"flag` as an example.

* First, it generates `open("abc.fa.gzip.xz.gz")`.
* Then, it looks at each extension from right to left, checking for "compression extensions" in a hardcoded list. Here, it will find first `.gz`, then `.xz`, then `.gzip`. From this it will generate nested `GzipDecompressorStream` and `XzDecompressorStream`. This is repeated in a while loop until there either is no extension at all, or the rightmost extension is not recognized as a compression extension.
* Then, it looks at the rightmost extension, `fa` in this cases and calls `readertype(::Val{:fa}, "flag")`. The idea is that downstream packages can override this method, e.g. FASTX would override it to `BioGenerics.IO.readertype(::Union{Val{:fa}, Val{:fna}}, flag) = FASTA.Reader`. The flag can be used as the downstream packages see fit, for any arguments to the readers/writers, but default to the empty string if not given.
* The final code produced by this macro is `FASTA.Reader(GzipDecompressorStream(XzDecompressorStream(GzipDecompressorStream(open("abc.fa.gzip.xz.gz")))))`

## `transcribe` function
It's pretty easy, this is its definition:
```
function transcribe(f::Function, writer::AbstractWriter, reader::AbstractReader)
    try
        for record in reader            
            transformed = f(record, reader)
            if transformed !== nothing
                write(writer, transformed)
            end
        end
    finally
        close(writer)
        close(reader)
    end
end
```
I.e. you give it a function that takes the reader, then it reads all records of the reader, applies the function, then write the result to the writer if it is not `nothing`

cc. @SabrinaJaye , @CiaranOMara , @kescobo 